### PR TITLE
Fix hero text alignment from left to center on mobile

### DIFF
--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -168,6 +168,7 @@ h2::selection {
 @media (max-width: 768px) {
   .header-container {
     margin-top: 7rem;
+    text-align: center;
   }
 
   .content-text h2 {


### PR DESCRIPTION
<!-- Complete this template with the required information -->

## Issue No: #123 

## What does this pull request do?
Correct the left aligned text of the hero button to center


## Screenshot if applicable


<img width="224" alt="alignment expected" src="https://user-images.githubusercontent.com/69409465/184516866-c7e4ae0b-d711-480c-bb2a-bfd2d70a4faa.png">

